### PR TITLE
Set dependency cooldown as a precaution against avoidable supply chain attacks

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.cooldown = {
+  minimumAge = "7 days"
+}


### PR DESCRIPTION


Context: https://github.com/scala-steward-org/scala-steward/pull/3762